### PR TITLE
"use Data::Printer" instead of "require Data::Printer"

### DIFF
--- a/lib/Daemonise.pm
+++ b/lib/Daemonise.pm
@@ -11,6 +11,7 @@ use lib "$Bin/../lib";
 use Sys::Syslog qw(:standard :macros);
 use Config::Any;
 use POSIX qw(strftime SIGTERM SIG_BLOCK SIG_UNBLOCK);
+use Data::Printer;
 
 =head1 SYNOPSIS
 
@@ -303,16 +304,9 @@ sub dump {    ## no critic (ProhibitBuiltinHomonyms)
         $options{multiline} = $nocolor_multiline ? 1 : 0;
     }
 
-    require Data::Printer;
     Data::Printer->import(%options) unless __PACKAGE__->can('p');
 
-    my $dump;
-    if (ref $obj) {
-        $dump = p($obj, %options);
-    }
-    else {
-        $dump = p(\$obj, %options);
-    }
+    my $dump = p($obj, %options);
 
     return $dump;
 }


### PR DESCRIPTION
I don't know why require was used, but for whatever reason it has been causing
the following error to appear in my syslog:

`edit: removed internal details.`

Changing this to "use Data::Printer" and getting rid of the extra call to p()
using the reference stopped it and I can load stuff again.

In my opinion, if you want to include a module at runtime use a "mixin" class.
Mouse has good support for this kind of thing.
