### PR TITLE
Type coerce Math::UInt64 into a string.

### DIFF
--- a/lib/Daemonise/Plugin/RabbitMQ.pm
+++ b/lib/Daemonise/Plugin/RabbitMQ.pm
@@ -53,12 +53,10 @@ use Try::Tiny;
 use Mouse::Util::TypeConstraints;
 
 subtype 'MathUInt64' => as 'Object' => where {
-    say "Checking MathUInt";
     $_->isa('Math::UInt64');
 };
 
 subtype 'MathInt64' => as 'Object' => where {
-    say "Checking MathInt";
     $_->isa('Math::Int64');
 };
 

--- a/lib/Daemonise/Plugin/RabbitMQ.pm
+++ b/lib/Daemonise/Plugin/RabbitMQ.pm
@@ -50,6 +50,19 @@ use Try::Tiny;
 
 =cut
 
+use Mouse::Util::TypeConstraints;
+
+subytpe 'LastDeliveryTagMathUInt64' => as 'Object' => where {
+    $_->isa('Math::UInt64') or $_->isa('Math::Int64');
+};
+
+
+coerce 'Str' => from 'LastDeliveryTagMathUInt64' => via {
+    return ""+$_;
+};
+
+no Mouse::Util::TypeConstraints;
+
 our $js = JSON->new;
 $js->utf8;
 $js->allow_blessed;
@@ -165,6 +178,7 @@ has 'last_delivery_tag' => (
     is      => 'rw',
     isa     => 'Str',
     lazy    => 1,
+    coerce => 1,
     default => sub { '' },
 );
 

--- a/lib/Daemonise/Plugin/RabbitMQ.pm
+++ b/lib/Daemonise/Plugin/RabbitMQ.pm
@@ -52,13 +52,20 @@ use Try::Tiny;
 
 use Mouse::Util::TypeConstraints;
 
-subytpe 'LastDeliveryTagMathUInt64' => as 'Object' => where {
-    $_->isa('Math::UInt64') or $_->isa('Math::Int64');
+subtype 'MathUInt64' => as 'Object' => where {
+    say "Checking MathUInt";
+    $_->isa('Math::UInt64');
 };
 
+subtype 'MathInt64' => as 'Object' => where {
+    say "Checking MathInt";
+    $_->isa('Math::Int64');
+};
 
-coerce 'Str' => from 'LastDeliveryTagMathUInt64' => via {
-    return ""+$_;
+coerce 'Str' => from 'MathUInt64' => via {
+    return "$_";
+} => from 'MathInt64' => via {
+    return "$_";
 };
 
 no Mouse::Util::TypeConstraints;
@@ -170,6 +177,7 @@ has 'rabbit_consumer_tag' => (
     default => sub { '' },
 );
 
+
 =head2 last_delivery_tag
 
 =cut
@@ -178,7 +186,7 @@ has 'last_delivery_tag' => (
     is      => 'rw',
     isa     => 'Str',
     lazy    => 1,
-    coerce => 1,
+    coerce  => 1,
     default => sub { '' },
 );
 

--- a/t/test-type-constraint.t
+++ b/t/test-type-constraint.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+package WithoutConversion;
+use Mouse;
+use Modern::Perl;
+
+has test_type => (
+    is      => 'rw',
+    isa     => 'Str',
+    lazy    => 1,
+    default => sub {
+        return '';
+    }
+);
+
+package WithConversion;
+use Mouse;
+use Modern::Perl;
+use Mouse::Util::TypeConstraints;
+
+subtype 'MathUInt64' => as 'Object' => where {
+    say "Checking MathUInt";
+    $_->isa('Math::UInt64');
+};
+
+subtype 'MathInt64' => as 'Object' => where {
+    say "Checking MathInt";
+    $_->isa('Math::Int64');
+};
+
+coerce 'Str' => from 'MathUInt64' => via {
+    return "$_";
+} => from 'MathInt64' => via {
+    return "$_";
+};
+
+no Mouse::Util::TypeConstraints;
+
+has test_type => (
+    is      => 'rw',
+    isa     => 'Str',
+    lazy    => 1,
+    coerce  => 1,
+    default => sub {
+        return '';
+    },
+);
+
+use Test::More tests => 3;
+use Test::Exception;
+use Math::UInt64 qw/uint64/;
+my $longint = uint64("12345678901234567890");
+
+isa_ok( $longint, 'Math::UInt64' );
+
+throws_ok {
+    my $obj = WithoutConversion->new();
+    $obj->test_type($longint);
+
+}
+qr/Mouse::Util::throw_error/, 'Threw error because of wrong type.';
+
+lives_ok {
+    my $obj = WithConversion->new();
+    $obj->test_type($longint);
+}
+'Initialised class.';
+
+__END__


### PR DESCRIPTION
This might placate my wild assumption based on a stack trace and recent updates to a dependency
saying that the thing returns Math::UInt64 objects now.