### PR TITLE
fix the status command on FreeBSD

### DIFF
--- a/lib/Daemonise/Plugin/Daemon.pm
+++ b/lib/Daemonise/Plugin/Daemon.pm
@@ -300,7 +300,7 @@ sub check_pid_file {
         # this follows BSD syntax ps (BSD's and linux)
         # this will fail on Unix98 syntax ps (Solaris, etc)
     }
-    elsif (`ps p $$ | grep -v 'PID'` =~ /^\s*$$\s+.*$/) {
+    elsif (`ps p $$ | grep $$` =~ /^\s*$$\s+.*$/) {
 
         # can I play ps on myself ?
         $exists = `ps p $pid | grep -v 'PID'`;

--- a/lib/Daemonise/Plugin/Daemon.pm
+++ b/lib/Daemonise/Plugin/Daemon.pm
@@ -303,7 +303,7 @@ sub check_pid_file {
     elsif (`ps p $$ | grep $$` =~ /^\s*$$\s+.*$/) {
 
         # can I play ps on myself ?
-        $exists = `ps p $pid | grep -v 'PID'`;
+        $exists = `ps p $pid | grep $pid`;
 
     }
 


### PR DESCRIPTION
The current code has filtered out the resulting `ps` line as it was removing `PID` but that is part of the command that gets shown in the PS call ... took me a while to get that :)
